### PR TITLE
fix "title must be of type String and cannot be empty. ", issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug.yml
@@ -1,7 +1,7 @@
 name: "Bug report"
 description: "Reports regarding bug, slow performance, memory issues, installation issues"
 
-title: ""
+title: "[Bug] "
 labels: ["bug"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/02_new_feature.yml
+++ b/.github/ISSUE_TEMPLATE/02_new_feature.yml
@@ -1,7 +1,7 @@
 name: "Feature request"
 description: "Reports regarding bug, slow performance, memory issues, installation issues"
 
-title: ""
+title: "[New] "
 labels: ["enhancement", "documentation"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/03_docs.yml
+++ b/.github/ISSUE_TEMPLATE/03_docs.yml
@@ -1,7 +1,7 @@
 name: "Improve documentation"
 description: "Improve documentation, README etc."
 
-title: ""
+title: "[Docs] "
 labels: ["documentation"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/04_development.yml
+++ b/.github/ISSUE_TEMPLATE/04_development.yml
@@ -1,7 +1,7 @@
 name: "Revise development workflow"
 description: "This may update ./.github directory, ./pyproject.toml etc."
 
-title: ""
+title: "[Dev] "
 labels: ["development"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/05_test.yml
+++ b/.github/ISSUE_TEMPLATE/05_test.yml
@@ -1,7 +1,7 @@
 name: "Update tests"
 description: "This may update files in ./tests directory for pytest"
 
-title: ""
+title: "[Dev] "
 labels: ["development"]
 
 body:

--- a/.github/ISSUE_TEMPLATE/06_question.yml
+++ b/.github/ISSUE_TEMPLATE/06_question.yml
@@ -1,7 +1,7 @@
 name: "Question or no templates found"
 description: "All questions regarding this project and the library, tags may be changed later"
 
-title: ""
+title: "[General] "
 labels: ["question"]
 
 body:


### PR DESCRIPTION
## Related issues
#4 (follow up pull request #5)

## What was changed
fix error of YAML issue template: "title must be of type String and cannot be empty. "