### PR TITLE
Add parser of "dim.json" file and type checker with pyright

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,9 @@ jobs:
         run: poetry install --no-interaction --no-root --with test
 
       - name: Linting Python codes
-        run: poetry run flake8 dim
+        run: |
+          poetry run flake8 dim
+          poetry run pyright --warnings
 
       - name: run quality check tests
         run: poetry run pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Linting Python codes
         run: |
-          poetry run flake8 dim
+          poetry run pflake8 dim
           poetry run pyright --warnings
 
       - name: run quality check tests

--- a/dim/__init__.py
+++ b/dim/__init__.py
@@ -2,3 +2,4 @@
 # -*- coding: utf-8 -*-
 
 from dim.__version__ import __version__  # noqa: F401
+from dim.locker.locker import Locker  # noqa: F401

--- a/dim/__version__.py
+++ b/dim/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/dim/locker/_dim_json.py
+++ b/dim/locker/_dim_json.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import annotations
-from typing import Dict, Optional
+from typing import Optional
 from dataclasses import dataclass, field
 from dataclasses_json import DataClassJsonMixin
 
@@ -26,7 +26,7 @@ class _DimJsonContent(DataClassJsonMixin):
     catalogUrl: Optional[str] = field(default=None)
     catalogResourceId: Optional[str] = field(default=None)
     postProcesses: list[str] = field(default_factory=list)
-    headers: Dict[str, str] = field(default_factory=dict)
+    headers: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass

--- a/dim/locker/_dim_json.py
+++ b/dim/locker/_dim_json.py
@@ -21,6 +21,7 @@ class _DimJsonContent(DataClassJsonMixin):
     Note:
         URL of CKAN is https://www.geospatial.jp/ckan/
     """
+    __dataclass_fields__: dict
     name: str
     url: Optional[str] = field(default=None)
     catalogUrl: Optional[str] = field(default=None)

--- a/dim/locker/_dim_json.py
+++ b/dim/locker/_dim_json.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from dataclasses import dataclass, field
+from dataclasses_json import DataClassJsonMixin
+
+
+@dataclass
+class _DimJsonContent(DataClassJsonMixin):
+    """Dataclass to parse the contents of dim.json file.
+
+    Args:
+        name: dataset title
+        url (optional): URL to retrieve the dataset
+        catalogUrl (optional): URL if dataset is available in CKAN
+        catalogResourceId (optional): dataset ID if dataset is available in CKAN
+        headers (optional): headers of the dataset
+
+    Note:
+        URL of CKAN is https://www.geospatial.jp/ckan/
+    """
+    name: str
+    url: str = field(default=None)
+    catalogUrl: str = field(default=None)
+    catalogResourceId: str = field(default=None)
+    postProcesses: list[str] = field(default_factory=list)
+    headers: dict[str] = field(default_factory=dict)
+
+
+@dataclass
+class _DimJson(DataClassJsonMixin):
+    """Dataclass to parse dim.json file.
+
+    Args:
+        contents: list of database definitions
+
+    Note:
+        fileVersion = 1.1: version number of dim.json file structure.
+    """
+    fileVersion: str = field(init=False)
+    contents: list[_DimJsonContent] = field(default_factory=list)
+
+    def __post_init__(self):
+        self.fileVersion = "1.1"

--- a/dim/locker/_dim_json.py
+++ b/dim/locker/_dim_json.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import annotations
-from typing import Any, Optional
+from typing import Optional
 from dataclasses import dataclass, field
 from dataclasses_json import DataClassJsonMixin
 
@@ -38,10 +38,7 @@ class _DimJson(DataClassJsonMixin):
         contents: list of database definitions
     """
     fileVersion: str = field(init=False)
-    contents: list[Any] = field(default_factory=list)
+    contents: list[_DimJsonContent] = field(default_factory=list)
 
     def __post_init__(self):
         self.fileVersion = "1.1"
-        for content in self.contents:
-            if not isinstance(self.contents, _DimJsonContent):
-                raise TypeError("Unexpected content was added")

--- a/dim/locker/_dim_json.py
+++ b/dim/locker/_dim_json.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from typing import Optional
+from typing import Dict, List, Optional
 from dataclasses import dataclass, field
 from dataclasses_json import DataClassJsonMixin
 
@@ -24,8 +24,8 @@ class _DimJsonContent(DataClassJsonMixin):
     url: Optional[str] = field(default=None)
     catalogUrl: Optional[str] = field(default=None)
     catalogResourceId: Optional[str] = field(default=None)
-    postProcesses: list[str] = field(default_factory=list)
-    headers: dict[str, str] = field(default_factory=dict)
+    postProcesses: List[str] = field(default_factory=list)
+    headers: Dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -37,7 +37,7 @@ class _DimJson(DataClassJsonMixin):
         contents: list of database definitions
     """
     fileVersion: str = field(init=False)
-    contents: list[_DimJsonContent] = field(default_factory=list)
+    contents: List[_DimJsonContent] = field(default_factory=list)
 
     def __post_init__(self):
         self.fileVersion = "1.1"

--- a/dim/locker/_dim_json.py
+++ b/dim/locker/_dim_json.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import annotations
-from typing import Optional
+from typing import Any, Optional
 from dataclasses import dataclass, field
 from dataclasses_json import DataClassJsonMixin
 
@@ -38,7 +38,10 @@ class _DimJson(DataClassJsonMixin):
         contents: list of database definitions
     """
     fileVersion: str = field(init=False)
-    contents: list[_DimJsonContent] = field(default_factory=list)
+    contents: list[Any] = field(default_factory=list)
 
     def __post_init__(self):
         self.fileVersion = "1.1"
+        for content in self.contents:
+            if not isinstance(self.contents, _DimJsonContent):
+                raise TypeError("Unexpected content was added")

--- a/dim/locker/_dim_json.py
+++ b/dim/locker/_dim_json.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+from typing import Optional
 from dataclasses import dataclass, field
 from dataclasses_json import DataClassJsonMixin
 
@@ -20,11 +22,11 @@ class _DimJsonContent(DataClassJsonMixin):
         URL of CKAN is https://www.geospatial.jp/ckan/
     """
     name: str
-    url: str = field(default=None)
-    catalogUrl: str = field(default=None)
-    catalogResourceId: str = field(default=None)
+    url: Optional[str] = field(default=None)
+    catalogUrl: Optional[str] = field(default=None)
+    catalogResourceId: Optional[str] = field(default=None)
     postProcesses: list[str] = field(default_factory=list)
-    headers: dict[str] = field(default_factory=dict)
+    headers: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -32,10 +34,8 @@ class _DimJson(DataClassJsonMixin):
     """Dataclass to parse dim.json file.
 
     Args:
+        fileVersion: version number of dim.json file structure, fixed to '1.1' at this time.
         contents: list of database definitions
-
-    Note:
-        fileVersion = 1.1: version number of dim.json file structure.
     """
     fileVersion: str = field(init=False)
     contents: list[_DimJsonContent] = field(default_factory=list)

--- a/dim/locker/_dim_json.py
+++ b/dim/locker/_dim_json.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from typing import Optional
 from dataclasses import dataclass, field
 from dataclasses_json import DataClassJsonMixin
+from nested_dataclasses import nested
 
 
+@nested
 @dataclass
 class _DimJsonContent(DataClassJsonMixin):
     """Dataclass to parse the contents of dim.json file.
@@ -29,6 +31,7 @@ class _DimJsonContent(DataClassJsonMixin):
     headers: dict[str, str] = field(default_factory=dict)
 
 
+@nested
 @dataclass
 class _DimJson(DataClassJsonMixin):
     """Dataclass to parse dim.json file.

--- a/dim/locker/_dim_json.py
+++ b/dim/locker/_dim_json.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import annotations
 from typing import Optional
 from dataclasses import dataclass, field
 from dataclasses_json import DataClassJsonMixin

--- a/dim/locker/_dim_json.py
+++ b/dim/locker/_dim_json.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import annotations
-from typing import Optional
+from typing import Dict, Optional
 from dataclasses import dataclass, field
 from dataclasses_json import DataClassJsonMixin
 
@@ -26,7 +26,7 @@ class _DimJsonContent(DataClassJsonMixin):
     catalogUrl: Optional[str] = field(default=None)
     catalogResourceId: Optional[str] = field(default=None)
     postProcesses: list[str] = field(default_factory=list)
-    headers: dict[str, str] = field(default_factory=dict)
+    headers: Dict[str, str] = field(default_factory=dict)
 
 
 @dataclass

--- a/dim/locker/_dim_json.py
+++ b/dim/locker/_dim_json.py
@@ -21,7 +21,6 @@ class _DimJsonContent(DataClassJsonMixin):
     Note:
         URL of CKAN is https://www.geospatial.jp/ckan/
     """
-    __dataclass_fields__: dict
     name: str
     url: Optional[str] = field(default=None)
     catalogUrl: Optional[str] = field(default=None)

--- a/dim/locker/_dim_json.py
+++ b/dim/locker/_dim_json.py
@@ -5,10 +5,8 @@ from __future__ import annotations
 from typing import Optional
 from dataclasses import dataclass, field
 from dataclasses_json import DataClassJsonMixin
-from nested_dataclasses import nested
 
 
-@nested
 @dataclass
 class _DimJsonContent(DataClassJsonMixin):
     """Dataclass to parse the contents of dim.json file.
@@ -31,7 +29,6 @@ class _DimJsonContent(DataClassJsonMixin):
     headers: dict[str, str] = field(default_factory=dict)
 
 
-@nested
 @dataclass
 class _DimJson(DataClassJsonMixin):
     """Dataclass to parse dim.json file.

--- a/dim/locker/locker.py
+++ b/dim/locker/locker.py
@@ -53,10 +53,10 @@ class Locker(object):
         with self._dim_json_path.open("w") as fh:
             json.dump(self._dim_json.to_dict(), fh, indent=4)
 
-    def lock(self) -> Self:
-        """Lock and write dim-lock.json.
+    def run(self) -> Self:
+        """Run locking and write dim-lock.json.
 
         Raises:
-            NotImplementedError
+            NotImplementedError: implemented later
         """
         raise NotImplementedError

--- a/dim/locker/locker.py
+++ b/dim/locker/locker.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 import json
 from pathlib import Path
+from typing import Any
 from typing_extensions import Self
 from dim.locker._dim_json import _DimJson
 
@@ -32,7 +33,7 @@ class Locker(object):
         return self.defined == other.defined
 
     @property
-    def defined(self) -> dict[str, str | list | dict]:
+    def defined(self) -> dict[str, Any]:
         """Parameter values defined by dim.json file.
         """
         return self._dim_json.to_dict()

--- a/dim/locker/locker.py
+++ b/dim/locker/locker.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing_extensions import Self
+from dim.locker._dim_json import _DimJson
+
+
+class Locker(object):
+    """Class to parse dim.json and write dim-lock.json file.
+
+    Args:
+        directory: directory which has dim.json to parse
+        errors (optional): "coerce" (create {directory}/dim.json if not exist) or "raise"
+
+    Raises:
+        FileNotFoundError: {errors} is not "raise" and {directory}/dim.json does not exist
+    """
+
+    def __init__(self, directory: str, errors: str = "coerce") -> None:
+        self._dim_json_path = Path(directory) / "dim.json"
+        if self._dim_json_path.exists():
+            self._read_dim_json()
+        elif errors == "coerce":
+            self._write_empty_dim_json()
+        else:
+            raise FileNotFoundError(f"dim.json not found in {directory=}")
+
+    def __eq__(self, other: Self) -> bool:
+        return self.defined == other.defined
+
+    @property
+    def defined(self) -> dict[str, str | list | dict]:
+        """Parameter values defined by dim.json file.
+        """
+        return self._dim_json.to_dict()
+
+    def _read_dim_json(self) -> None:
+        """Read {directory}/dim.json file.
+        """
+        self._dim_json_path.parent.mkdir(exist_ok=True)
+        with self._dim_json_path.open("r") as fh:
+            content = json.load(fh)
+        self._dim_json = _DimJson.from_dict(content)
+
+    def _write_empty_dim_json(self) -> None:
+        """Write empty {directory}/dim.json file.
+        """
+        self._dim_json = _DimJson()
+        with self._dim_json_path.open("w") as fh:
+            json.dump(self._dim_json.to_dict(), fh, indent=4)
+
+    def lock(self) -> Self:
+        """Lock and write dim-lock.json.
+
+        Raises:
+            NotImplementedError
+        """
+        raise NotImplementedError

--- a/dim/locker/locker.py
+++ b/dim/locker/locker.py
@@ -14,17 +14,17 @@ class Locker(object):
 
     Args:
         directory: directory which has dim.json to parse
-        errors (optional): "coerce" (create {directory}/dim.json if not exist) or "raise"
+        create_if_missing (optional): True (create {directory}/dim.json if not exist) or False (default)
 
     Raises:
         FileNotFoundError: {errors} is not "raise" and {directory}/dim.json does not exist
     """
 
-    def __init__(self, directory: str, errors: str = "coerce") -> None:
+    def __init__(self, directory: str, create_if_missing: bool = False) -> None:
         self._dim_json_path = Path(directory) / "dim.json"
         if self._dim_json_path.exists():
             self._read_dim_json()
-        elif errors == "coerce":
+        elif create_if_missing:
             self._write_empty_dim_json()
         else:
             raise FileNotFoundError(f"dim.json not found in {directory=}")

--- a/poetry.lock
+++ b/poetry.lock
@@ -128,14 +128,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "nested-dataclasses"
-version = "0.2"
-description = "Implements decorator `nested` that adds a parent and children to a dataclass."
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "nodeenv"
 version = "1.7.0"
 description = "Node.js virtual environment builder"
@@ -318,7 +310,7 @@ typing-extensions = ">=3.7.4"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "6076f20c2a3f6a4c1ebf1a471488659e8045e804b31bc4d66ddc35a34e0f4cfa"
+content-hash = "aacad423dc56563556f11e8e58bbf165527eafaaf2b2be2a9732cd9d5a02019c"
 
 [metadata.files]
 attrs = [
@@ -412,10 +404,6 @@ mccabe = [
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
-]
-nested-dataclasses = [
-    {file = "nested-dataclasses-0.2.tar.gz", hash = "sha256:f7fd5fca422f6f02477ca606c51032a2e73709559ed0b7cb1c8ece7baff8c827"},
-    {file = "nested_dataclasses-0.2-py3-none-any.whl", hash = "sha256:3322a7631c68b43509d2e77f53095f891483b415e7b7d98637389a0506652102"},
 ]
 nodeenv = [
     {file = "nodeenv-1.7.0-py2.py3-none-any.whl", hash = "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -47,6 +47,22 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli"]
 
 [[package]]
+name = "dataclasses-json"
+version = "0.5.7"
+description = "Easily serialize dataclasses to and from JSON"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+marshmallow = ">=3.3.0,<4.0.0"
+marshmallow-enum = ">=1.5.1,<2.0.0"
+typing-inspect = ">=0.4.0"
+
+[package.extras]
+dev = ["flake8", "hypothesis", "ipython", "mypy (>=0.710)", "portray", "pytest (>=6.2.3)", "simplejson", "types-dataclasses"]
+
+[[package]]
 name = "flake8"
 version = "5.0.4"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -68,6 +84,34 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "marshmallow"
+version = "3.18.0"
+description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+packaging = ">=17.0"
+
+[package.extras]
+dev = ["flake8 (==5.0.4)", "flake8-bugbear (==22.9.11)", "mypy (==0.971)", "pre-commit (>=2.4,<3.0)", "pytest", "pytz", "simplejson", "tox"]
+docs = ["alabaster (==0.7.12)", "autodocsumm (==0.2.9)", "sphinx (==5.1.1)", "sphinx-issues (==3.0.1)", "sphinx-version-warning (==1.1.2)"]
+lint = ["flake8 (==5.0.4)", "flake8-bugbear (==22.9.11)", "mypy (==0.971)", "pre-commit (>=2.4,<3.0)"]
+tests = ["pytest", "pytz", "simplejson"]
+
+[[package]]
+name = "marshmallow-enum"
+version = "1.5.1"
+description = "Enum field for Marshmallow"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+marshmallow = ">=2.0.0"
+
+[[package]]
 name = "mccabe"
 version = "0.7.0"
 description = "McCabe checker, plugin for flake8"
@@ -76,10 +120,18 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -126,7 +178,7 @@ python-versions = ">=3.6"
 name = "pyparsing"
 version = "3.0.9"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6.8"
 
@@ -196,10 +248,30 @@ category = "dev"
 optional = false
 python-versions = ">=3.7"
 
+[[package]]
+name = "typing-extensions"
+version = "4.4.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "typing-inspect"
+version = "0.8.0"
+description = "Runtime inspection utilities for typing module."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+mypy-extensions = ">=0.3.0"
+typing-extensions = ">=3.7.4"
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "9732b36baca73eaf41a16330d2127e2edc1d01410059db907a464bb7087998ce"
+content-hash = "8153633615b19e0be57f2c25c25aea8c736a39d7463f62a8c11e7601781d8c7c"
 
 [metadata.files]
 attrs = [
@@ -266,6 +338,10 @@ coverage = [
     {file = "coverage-6.5.0-pp36.pp37.pp38-none-any.whl", hash = "sha256:1431986dac3923c5945271f169f59c45b8802a114c8f548d611f2015133df77a"},
     {file = "coverage-6.5.0.tar.gz", hash = "sha256:f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84"},
 ]
+dataclasses-json = [
+    {file = "dataclasses-json-0.5.7.tar.gz", hash = "sha256:c2c11bc8214fbf709ffc369d11446ff6945254a7f09128154a7620613d8fda90"},
+    {file = "dataclasses_json-0.5.7-py3-none-any.whl", hash = "sha256:bc285b5f892094c3a53d558858a88553dd6a61a11ab1a8128a0e554385dcc5dd"},
+]
 flake8 = [
     {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
     {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
@@ -274,9 +350,21 @@ iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
+marshmallow = [
+    {file = "marshmallow-3.18.0-py3-none-any.whl", hash = "sha256:35e02a3a06899c9119b785c12a22f4cda361745d66a71ab691fd7610202ae104"},
+    {file = "marshmallow-3.18.0.tar.gz", hash = "sha256:6804c16114f7fce1f5b4dadc31f4674af23317fcc7f075da21e35c1a35d781f7"},
+]
+marshmallow-enum = [
+    {file = "marshmallow-enum-1.5.1.tar.gz", hash = "sha256:38e697e11f45a8e64b4a1e664000897c659b60aa57bfa18d44e226a9920b6e58"},
+    {file = "marshmallow_enum-1.5.1-py2.py3-none-any.whl", hash = "sha256:57161ab3dbfde4f57adeb12090f39592e992b9c86d206d02f6bd03ebec60f072"},
+]
 mccabe = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
     {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
@@ -321,4 +409,12 @@ toml = [
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
+    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+]
+typing-inspect = [
+    {file = "typing_inspect-0.8.0-py3-none-any.whl", hash = "sha256:5fbf9c1e65d4fa01e701fe12a5bca6c6e08a4ffd5bc60bfac028253a447c5188"},
+    {file = "typing_inspect-0.8.0.tar.gz", hash = "sha256:8b1ff0c400943b6145df8119c41c244ca8207f1f10c9c057aeed1560e4806e3d"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -128,6 +128,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "nested-dataclasses"
+version = "0.2"
+description = "Implements decorator `nested` that adds a parent and children to a dataclass."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "nodeenv"
 version = "1.7.0"
 description = "Node.js virtual environment builder"
@@ -310,7 +318,7 @@ typing-extensions = ">=3.7.4"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "aacad423dc56563556f11e8e58bbf165527eafaaf2b2be2a9732cd9d5a02019c"
+content-hash = "6076f20c2a3f6a4c1ebf1a471488659e8045e804b31bc4d66ddc35a34e0f4cfa"
 
 [metadata.files]
 attrs = [
@@ -404,6 +412,10 @@ mccabe = [
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+nested-dataclasses = [
+    {file = "nested-dataclasses-0.2.tar.gz", hash = "sha256:f7fd5fca422f6f02477ca606c51032a2e73709559ed0b7cb1c8ece7baff8c827"},
+    {file = "nested_dataclasses-0.2-py3-none-any.whl", hash = "sha256:3322a7631c68b43509d2e77f53095f891483b415e7b7d98637389a0506652102"},
 ]
 nodeenv = [
     {file = "nodeenv-1.7.0-py2.py3-none-any.whl", hash = "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -128,6 +128,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "nodeenv"
+version = "1.7.0"
+description = "Node.js virtual environment builder"
+category = "dev"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -198,6 +209,21 @@ flake8 = "5.0.4"
 tomli = {version = "*", markers = "python_version < \"3.11\""}
 
 [[package]]
+name = "pyright"
+version = "1.1.274"
+description = "Command line wrapper for pyright"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+
+[package.extras]
+all = ["twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
+
+[[package]]
 name = "pytest"
 version = "7.1.3"
 description = "pytest: simple powerful testing with Python"
@@ -231,6 +257,19 @@ pytest = ">=4.6"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+
+[[package]]
+name = "setuptools"
+version = "65.4.1"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "toml"
@@ -271,7 +310,7 @@ typing-extensions = ">=3.7.4"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "8153633615b19e0be57f2c25c25aea8c736a39d7463f62a8c11e7601781d8c7c"
+content-hash = "aacad423dc56563556f11e8e58bbf165527eafaaf2b2be2a9732cd9d5a02019c"
 
 [metadata.files]
 attrs = [
@@ -366,6 +405,10 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
+nodeenv = [
+    {file = "nodeenv-1.7.0-py2.py3-none-any.whl", hash = "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e"},
+    {file = "nodeenv-1.7.0.tar.gz", hash = "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"},
+]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
@@ -394,6 +437,10 @@ pyproject-flake8 = [
     {file = "pyproject-flake8-5.0.4.post1.tar.gz", hash = "sha256:c2dfdf1064f47efbb2e4faf1a32b0b6a6ea67dc4d1debb98d862b0cdee377941"},
     {file = "pyproject_flake8-5.0.4.post1-py2.py3-none-any.whl", hash = "sha256:457e52dde1b7a1f84b5230c70d61afa58ced64a44b81a609f19e972319fa68ed"},
 ]
+pyright = [
+    {file = "pyright-1.1.274-py3-none-any.whl", hash = "sha256:f0f9eb1b26871c5ac8bf3f32de6aafaffbfb252f5d7dc0fda2c6cba37e2c4232"},
+    {file = "pyright-1.1.274.tar.gz", hash = "sha256:2a1a8cc4a9109d0d934b988c0099fc4b9189567d1a258b634f7babe352ba6661"},
+]
 pytest = [
     {file = "pytest-7.1.3-py3-none-any.whl", hash = "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"},
     {file = "pytest-7.1.3.tar.gz", hash = "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"},
@@ -401,6 +448,10 @@ pytest = [
 pytest-cov = [
     {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
     {file = "pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
+]
+setuptools = [
+    {file = "setuptools-65.4.1-py3-none-any.whl", hash = "sha256:1b6bdc6161661409c5f21508763dc63ab20a9ac2f8ba20029aaaa7fdb9118012"},
+    {file = "setuptools-65.4.1.tar.gz", hash = "sha256:3050e338e5871e70c72983072fe34f6032ae1cdeeeb67338199c2f74e083a80e"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ pytest-cov = "^4.0.0"
 flake8 = "^5.0.4"
 autopep8 = "^1.7.0"
 pyproject-flake8 = "^5.0.4.post1"
+pyright = "^1.1.274"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -40,3 +41,6 @@ extend-ignore = ["E501"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 filterwarnings = ["error"]
+
+[tool.pyright]
+include = ["dim"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
+dataclasses-json = "^0.5.7"
+typing-extensions = "^4.4.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
 python = "^3.8"
 dataclasses-json = "^0.5.7"
 typing-extensions = "^4.4.0"
-nested-dataclasses = "^0.2"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.1.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 python = "^3.8"
 dataclasses-json = "^0.5.7"
 typing-extensions = "^4.4.0"
+nested-dataclasses = "^0.2"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.1.3"

--- a/tests/test_locker.py
+++ b/tests/test_locker.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from pytest import raises
+from dim import Locker
+from dim.locker._dim_json import _DimJson
+
+
+def test_start_with_empty(tmpdir):
+    with raises(FileNotFoundError):
+        Locker(directory=tmpdir, errors="raise")
+    # Write dim.json
+    locker_empty = Locker(directory=tmpdir)
+    assert locker_empty.defined == _DimJson().to_dict()
+    # Read exist dim.json
+    locker = Locker(directory=tmpdir, errors="raise")
+    assert locker == locker_empty

--- a/tests/test_locker.py
+++ b/tests/test_locker.py
@@ -8,10 +8,10 @@ from dim.locker._dim_json import _DimJson
 
 def test_start_with_empty(tmpdir):
     with raises(FileNotFoundError):
-        Locker(directory=tmpdir, errors="raise")
+        Locker(directory=tmpdir, create_if_missing=False)
     # Write dim.json
-    locker_empty = Locker(directory=tmpdir)
+    locker_empty = Locker(directory=tmpdir, create_if_missing=True)
     assert locker_empty.defined == _DimJson().to_dict()
     # Read exist dim.json
-    locker = Locker(directory=tmpdir, errors="raise")
+    locker = Locker(directory=tmpdir, create_if_missing=False)
     assert locker == locker_empty


### PR DESCRIPTION
## Related issues
#1, #15 and #16

## What was changed
- Close #15 by adding `Locker` class, just to clarify the JSON data structure of "dim.json" file. This may be removed later before 1.0.0 release.
- Add `Locker().run()` which raises `NotImplmentedError`. This is a key method of `Locker`, but will be discussed in new issues.
- Close #16 by adding `pyright` in quality check workflow.
- Regarding #1, use `pflake8` command instead of `flake8` in quality check workflow to use config in "pyproject.toml" file.
- bump up to version 0.2.0